### PR TITLE
test: add test to no read '-' as literal in character classes

### DIFF
--- a/test/character_class_ranges_test.py
+++ b/test/character_class_ranges_test.py
@@ -33,3 +33,6 @@ class RegexWildcardTest(unittest.TestCase):
 
     def test_multiple_correct_literals2_rejection(self):
         self.assertFalse(self.testee("ay4c"))
+
+    def test_reject_range_symbol(self):
+        self.assertFalse(self.testee("a-c"))


### PR DESCRIPTION
Test if `-` in `[a-z]` is rejected as literal.